### PR TITLE
feat: add eksctl v0.226.0 binary

### DIFF
--- a/iximiuz/rootfs/dev/machine/README.md
+++ b/iximiuz/rootfs/dev/machine/README.md
@@ -26,6 +26,7 @@ A child image built on top of [`ubuntu-24-04-rootfs`](../../ubuntu/README.md). U
 | k9s | v0.50.10 | GitHub release |
 | kubectx / kubens | v0.9.5 | GitHub release |
 | stern | v1.33.0 | GitHub release |
+| eksctl | v0.226.0 | GitHub release |
 | Terraform | Latest | HashiCorp apt repo |
 | GitHub CLI | Latest | Official GitHub apt repo |
 | AWS CLI | v2 (latest) | Official installer |
@@ -56,7 +57,7 @@ dev/machine/
 ├── welcome                            # Welcome banner (copied to $HOME/.welcome)
 └── scripts/
     ├── install-docker.sh              # Docker CE - official Docker apt repo
-    ├── install-tools.sh               # Full DevOps toolchain - 27 phases
+    ├── install-tools.sh               # Full DevOps toolchain - 28 phases
     ├── install-cloudflared.sh         # Cloudflare Tunnel CLI
     ├── setup-completions.sh           # System-wide bash + zsh completions
     └── customize-bashrc.sh            # Aliases and helpers → ~/.bashrc

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -36,7 +36,7 @@ TRIVY_VERSION="0.64.1"
 GITLEAKS_VERSION="v8.28.0"
 COSIGN_VERSION="v3.0.3"
 SYFT_VERSION="v1.26.1"
-EKSCTL_VERSION="v0.207.0"
+EKSCTL_VERSION="v0.226.0"
 
 # =============================================================================
 # PHASE 1: Base system packages
@@ -384,17 +384,22 @@ syft --version
 
 # =============================================================================
 # PHASE 26: eksctl — official GitHub release (eksctl-io/eksctl)
-# https://eksctl.io/installation/
+# https://docs.aws.amazon.com/eks/latest/eksctl/installation.html
 # =============================================================================
 log_phase "PHASE 26: eksctl ${EKSCTL_VERSION}"
 
-ARCH="$(uname -m)"
-[[ "$ARCH" == "x86_64" ]] && EKSCTL_ARCH="amd64" || EKSCTL_ARCH="arm64"
+# For ARM systems, set ARCH to: arm64, armv6 or armv7
+ARCH=amd64
+PLATFORM=$(uname -s)_${ARCH}
 
-curl -fsSL "https://github.com/eksctl-io/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_${EKSCTL_ARCH}.tar.gz" \
-  -o /tmp/eksctl.tar.gz
-tar -xzf /tmp/eksctl.tar.gz -C /usr/local/bin eksctl
-chmod +x /usr/local/bin/eksctl && rm /tmp/eksctl.tar.gz
+curl -sLO "https://github.com/eksctl-io/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_${PLATFORM}.tar.gz"
+
+# Verify checksum
+curl -sL "https://github.com/eksctl-io/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_checksums.txt" \
+  | grep "${PLATFORM}" | sha256sum --check
+
+tar -xzf "eksctl_${PLATFORM}.tar.gz" -C /tmp && rm "eksctl_${PLATFORM}.tar.gz"
+install -m 0755 /tmp/eksctl /usr/local/bin && rm /tmp/eksctl
 eksctl version
 
 # =============================================================================

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -36,6 +36,7 @@ TRIVY_VERSION="0.64.1"
 GITLEAKS_VERSION="v8.28.0"
 COSIGN_VERSION="v3.0.3"
 SYFT_VERSION="v1.26.1"
+EKSCTL_VERSION="v0.207.0"
 
 # =============================================================================
 # PHASE 1: Base system packages
@@ -382,9 +383,24 @@ curl -fsSL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
 syft --version
 
 # =============================================================================
-# PHASE 26: Python tools via pip
+# PHASE 26: eksctl — official GitHub release (eksctl-io/eksctl)
+# https://eksctl.io/installation/
 # =============================================================================
-log_phase "PHASE 26: Python tools via pip"
+log_phase "PHASE 26: eksctl ${EKSCTL_VERSION}"
+
+ARCH="$(uname -m)"
+[[ "$ARCH" == "x86_64" ]] && EKSCTL_ARCH="amd64" || EKSCTL_ARCH="arm64"
+
+curl -fsSL "https://github.com/eksctl-io/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_${EKSCTL_ARCH}.tar.gz" \
+  -o /tmp/eksctl.tar.gz
+tar -xzf /tmp/eksctl.tar.gz -C /usr/local/bin eksctl
+chmod +x /usr/local/bin/eksctl && rm /tmp/eksctl.tar.gz
+eksctl version
+
+# =============================================================================
+# PHASE 27: Python tools via pip
+# =============================================================================
+log_phase "PHASE 27: Python tools via pip"
 
 pip3 install --break-system-packages \
   pre-commit \
@@ -397,9 +413,9 @@ ansible --version
 yamllint --version
 
 # =============================================================================
-# PHASE 27: Final cleanup
+# PHASE 28: Final cleanup
 # =============================================================================
-log_phase "PHASE 27: Final cleanup"
+log_phase "PHASE 28: Final cleanup"
 
 apt-get autoremove -y
 apt-get clean

--- a/iximiuz/rootfs/dev/machine/welcome
+++ b/iximiuz/rootfs/dev/machine/welcome
@@ -9,7 +9,7 @@
 
   RUNTIMES        java 21   python3    node LTS    npm    maven
   CONTAINERS      docker    docker-compose    buildx    skopeo    dive    hadolint
-  KUBERNETES      kubectl   helm    kustomize    k9s    kubectx    kubens    stern
+  KUBERNETES      kubectl   helm    kustomize    k9s    kubectx    kubens    stern    eksctl
   INFRA & CI/CD   terraform aws cli v2  ansible  ansible-lint  pre-commit  yamllint  gh
   SECURITY        trivy     gitleaks    cosign    syft
   DATA & SEARCH   jq        yq          fzf       rg


### PR DESCRIPTION
## Summary

Adds `eksctl` v0.226.0 to the SilverStack Dev Machine rootfs toolchain.

## Changes

### `scripts/install-tools.sh`
- Added `EKSCTL_VERSION="v0.226.0"` to the pinned versions block
- Added **PHASE 26** — eksctl installation using the official AWS docs method:
  - `PLATFORM=$(uname -s)_${ARCH}` naming convention
  - SHA256 checksum verification against `eksctl_checksums.txt`
  - Binary placed via `install -m 0755`
- Renumbered Python pip phase → **27**, Final cleanup → **28**

### `welcome`
- Added `eksctl` to the `KUBERNETES` row in the pre-installed tools banner

### `README.md`
- Added `eksctl v0.226.0` row to the **What's Inside** table (grouped with Kubernetes tools, after `stern`)
- Updated directory structure comment: `27 phases` → `28 phases`

## Reference

- Official install docs: https://docs.aws.amazon.com/eks/latest/eksctl/installation.html
- Release: https://github.com/eksctl-io/eksctl/releases/tag/v0.226.0