### PR TITLE
feat: add database CLI clients (Phase 28 & 29)

### DIFF
--- a/iximiuz/rootfs/dev/machine/README.md
+++ b/iximiuz/rootfs/dev/machine/README.md
@@ -1,6 +1,6 @@
 # Dev Machine Rootfs
 
-Production-grade DevOps workstation rootfs for iximiuz playgrounds. Boots via Ubuntu 24.04 with the complete SilverStack DevOps toolchain pre-installed - Docker, Kubernetes, Terraform, AWS CLI, security tools, and more. No setup required.
+Production-grade DevOps workstation rootfs for iximiuz playgrounds. Boots via Ubuntu 24.04 with the complete SilverStack DevOps toolchain pre-installed - Docker, Kubernetes, Terraform, AWS CLI, security tools, database CLI clients, and more. No setup required.
 
 ## What It Is
 
@@ -48,6 +48,11 @@ A child image built on top of [`ubuntu-24-04-rootfs`](../../ubuntu/README.md). U
 | nmap | Latest | `apt` |
 | socat | Latest | `apt` |
 | cloudflared | Latest | Cloudflare apt repo |
+| mysql-client | Latest | `apt` |
+| postgresql-client | Latest | `apt` |
+| sqlite3 | Latest | `apt` |
+| redis-tools | Latest | `apt` |
+| mongosh | Latest | Official MongoDB apt repo |
 
 ## Directory Structure
 
@@ -57,7 +62,7 @@ dev/machine/
 ├── welcome                            # Welcome banner (copied to $HOME/.welcome)
 └── scripts/
     ├── install-docker.sh              # Docker CE - official Docker apt repo
-    ├── install-tools.sh               # Full DevOps toolchain - 28 phases
+    ├── install-tools.sh               # Full DevOps toolchain - 30 phases
     ├── install-cloudflared.sh         # Cloudflare Tunnel CLI
     ├── setup-completions.sh           # System-wide bash + zsh completions
     └── customize-bashrc.sh            # Aliases and helpers → ~/.bashrc

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -418,9 +418,50 @@ ansible --version
 yamllint --version
 
 # =============================================================================
-# PHASE 28: Final cleanup
+# PHASE 28: Database CLI Clients — official Ubuntu repos
+# https://dev.mysql.com/doc/refman/en/mysql.html
+# https://www.postgresql.org/docs/current/app-psql.html
+# https://sqlite.org/cli.html
+# https://redis.io/docs/ui/cli/
 # =============================================================================
-log_phase "PHASE 28: Final cleanup"
+log_phase "PHASE 28: Database CLI Clients"
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  mysql-client \
+  postgresql-client \
+  sqlite3 \
+  redis-tools
+
+mysql --version
+psql --version
+sqlite3 --version
+redis-cli --version
+apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# =============================================================================
+# PHASE 29: mongosh — official MongoDB apt repo
+# https://www.mongodb.com/docs/mongodb-shell/install/
+# =============================================================================
+log_phase "PHASE 29: mongosh"
+
+curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc \
+  | gpg --dearmor -o /etc/apt/keyrings/mongodb-server-8.0.gpg
+chmod 644 /etc/apt/keyrings/mongodb-server-8.0.gpg
+
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.gpg] \
+  https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" \
+  > /etc/apt/sources.list.d/mongodb-org-8.0.list
+
+apt-get update
+apt-get install -y --no-install-recommends mongodb-mongosh
+mongosh --version
+apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# =============================================================================
+# PHASE 30: Final cleanup
+# =============================================================================
+log_phase "PHASE 30: Final cleanup"
 
 apt-get autoremove -y
 apt-get clean

--- a/iximiuz/rootfs/dev/machine/welcome
+++ b/iximiuz/rootfs/dev/machine/welcome
@@ -14,6 +14,7 @@
   SECURITY        trivy     gitleaks    cosign    syft
   DATA & SEARCH   jq        yq          fzf       rg
   NETWORKING      nmap      openssl     ssh       socat        cloudflared
+  DB CLIENTS      mysql     psql        sqlite3   redis-cli    mongosh
 
   Pre-defined shortcuts:
 


### PR DESCRIPTION
## Summary

Adds database CLI clients to the Dev Machine rootfs image. Previously, no database tooling was installed, causing `mysql: command not found` when trying to connect to external databases (e.g., AWS RDS) from the playground.

## Changes

### `scripts/install-tools.sh`
- **Phase 28** — Database CLI Clients via `apt`: `mysql-client`, `postgresql-client`, `sqlite3`, `redis-tools`
- **Phase 29** — `mongosh` via official MongoDB 8.0 apt repo (separate phase, own GPG keyring)
- **Phase 30** — Final cleanup (renumbered from 28)

### `README.md`
- Updated toolchain description to mention database CLI clients
- Updated phase count in Directory Structure: `28 phases` → `30 phases`
- Added 5 new rows to the **What's Inside** table: `mysql-client`, `postgresql-client`, `sqlite3`, `redis-tools`, `mongosh`

### `welcome`
- Added `DB CLIENTS` line under Pre-installed tools:
  ```
  DB CLIENTS      mysql     psql        sqlite3   redis-cli    mongosh
  ```

## Why

When working on Kubernetes projects that connect to external databases (AWS RDS MySQL/PostgreSQL, Redis, MongoDB), there was no CLI client available to verify connectivity or run quick queries. This addition covers all common database engines used in DevOps workflows.