### PR TITLE
feat(dev-machine): add act v0.2.89, helmfile v1.5.2, helm-diff & skaffold

### DIFF
--- a/iximiuz/rootfs/dev/machine/README.md
+++ b/iximiuz/rootfs/dev/machine/README.md
@@ -34,6 +34,10 @@ A child image built on top of [`ubuntu-24-04-rootfs`](../../ubuntu/README.md). U
 | ansible-lint | Latest | `pip3` |
 | pre-commit | Latest | `pip3` |
 | yamllint | Latest | `pip3` |
+| act | v0.2.89 | GitHub release |
+| helmfile | v1.5.2 | GitHub release |
+| helm-diff | Latest (via `helm plugin install`) | Helm plugin |
+| skaffold | Latest stable | Official GCS binary |
 | Skopeo | Latest | `apt` |
 | dive | v0.13.1 | GitHub release |
 | hadolint | v2.12.0 | GitHub release |
@@ -62,7 +66,7 @@ dev/machine/
 ├── welcome                            # Welcome banner (copied to $HOME/.welcome)
 └── scripts/
     ├── install-docker.sh              # Docker CE - official Docker apt repo
-    ├── install-tools.sh               # Full DevOps toolchain - 30 phases
+    ├── install-tools.sh               # Full DevOps toolchain - 35 phases
     ├── install-cloudflared.sh         # Cloudflare Tunnel CLI
     ├── setup-completions.sh           # System-wide bash + zsh completions
     └── customize-bashrc.sh            # Aliases and helpers → ~/.bashrc

--- a/iximiuz/rootfs/dev/machine/README.md
+++ b/iximiuz/rootfs/dev/machine/README.md
@@ -66,7 +66,7 @@ dev/machine/
 ├── welcome                            # Welcome banner (copied to $HOME/.welcome)
 └── scripts/
     ├── install-docker.sh              # Docker CE - official Docker apt repo
-    ├── install-tools.sh               # Full DevOps toolchain - 35 phases
+    ├── install-tools.sh               # Full DevOps toolchain - 34 phases
     ├── install-cloudflared.sh         # Cloudflare Tunnel CLI
     ├── setup-completions.sh           # System-wide bash + zsh completions
     └── customize-bashrc.sh            # Aliases and helpers → ~/.bashrc

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -461,23 +461,10 @@ mongosh --version
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # =============================================================================
-# PHASE 30: Final cleanup
-# =============================================================================
-log_phase "PHASE 30: Final cleanup"
-
-apt-get autoremove -y
-apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-log_info "============================================"
-log_info "All tools installed successfully."
-log_info "============================================"
-
-# =============================================================================
-# PHASE 31: act — GitHub Actions local runner
+# PHASE 30: act — GitHub Actions local runner
 # https://github.com/nektos/act/releases/tag/v0.2.89
 # =============================================================================
-log_phase "PHASE 31: act ${ACT_VERSION}"
+log_phase "PHASE 30: act ${ACT_VERSION}"
 
 curl -fsSL "https://github.com/nektos/act/releases/download/${ACT_VERSION}/act_Linux_x86_64.tar.gz" \
   -o /tmp/act.tar.gz
@@ -487,10 +474,10 @@ rm /tmp/act.tar.gz
 act --version
 
 # =============================================================================
-# PHASE 32: helmfile — Helm release orchestrator
+# PHASE 31: helmfile — Helm release orchestrator
 # https://github.com/helmfile/helmfile/releases/tag/v1.5.2
 # =============================================================================
-log_phase "PHASE 32: helmfile ${HELMFILE_VERSION}"
+log_phase "PHASE 31: helmfile ${HELMFILE_VERSION}"
 
 curl -fsSL "https://github.com/helmfile/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION#v}_linux_amd64.tar.gz" \
   -o /tmp/helmfile.tar.gz
@@ -500,19 +487,19 @@ rm /tmp/helmfile.tar.gz
 helmfile version
 
 # =============================================================================
-# PHASE 33: helm-diff plugin — required by helmfile
+# PHASE 32: helm-diff plugin — required by helmfile
 # https://github.com/databus23/helm-diff
 # =============================================================================
-log_phase "PHASE 33: helm-diff plugin"
+log_phase "PHASE 32: helm-diff plugin"
 
 helm plugin install https://github.com/databus23/helm-diff
 helm plugin list
 
 # =============================================================================
-# PHASE 34: skaffold — latest stable binary
+# PHASE 33: skaffold — latest stable binary
 # https://skaffold.dev/docs/install/
 # =============================================================================
-log_phase "PHASE 34: skaffold (latest stable)"
+log_phase "PHASE 33: skaffold (latest stable)"
 
 curl -fsSL https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 \
   -o /tmp/skaffold
@@ -521,9 +508,9 @@ rm /tmp/skaffold
 skaffold version
 
 # =============================================================================
-# PHASE 35: Final cleanup
+# PHASE 34: Final cleanup
 # =============================================================================
-log_phase "PHASE 35: Final cleanup"
+log_phase "PHASE 34: Final cleanup"
 
 apt-get autoremove -y
 apt-get clean

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -37,6 +37,8 @@ GITLEAKS_VERSION="v8.28.0"
 COSIGN_VERSION="v3.0.3"
 SYFT_VERSION="v1.26.1"
 EKSCTL_VERSION="v0.226.0"
+ACT_VERSION="v0.2.89"
+HELMFILE_VERSION="v1.5.2"
 
 # =============================================================================
 # PHASE 1: Base system packages
@@ -462,6 +464,66 @@ apt-get clean && rm -rf /var/lib/apt/lists/*
 # PHASE 30: Final cleanup
 # =============================================================================
 log_phase "PHASE 30: Final cleanup"
+
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+log_info "============================================"
+log_info "All tools installed successfully."
+log_info "============================================"
+
+# =============================================================================
+# PHASE 31: act — GitHub Actions local runner
+# https://github.com/nektos/act/releases/tag/v0.2.89
+# =============================================================================
+log_phase "PHASE 31: act ${ACT_VERSION}"
+
+curl -fsSL "https://github.com/nektos/act/releases/download/${ACT_VERSION}/act_Linux_x86_64.tar.gz" \
+  -o /tmp/act.tar.gz
+tar -xzf /tmp/act.tar.gz -C /usr/local/bin act
+chmod +x /usr/local/bin/act
+rm /tmp/act.tar.gz
+act --version
+
+# =============================================================================
+# PHASE 32: helmfile — Helm release orchestrator
+# https://github.com/helmfile/helmfile/releases/tag/v1.5.2
+# =============================================================================
+log_phase "PHASE 32: helmfile ${HELMFILE_VERSION}"
+
+curl -fsSL "https://github.com/helmfile/helmfile/releases/download/${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION#v}_linux_amd64.tar.gz" \
+  -o /tmp/helmfile.tar.gz
+tar -xzf /tmp/helmfile.tar.gz -C /usr/local/bin helmfile
+chmod +x /usr/local/bin/helmfile
+rm /tmp/helmfile.tar.gz
+helmfile version
+
+# =============================================================================
+# PHASE 33: helm-diff plugin — required by helmfile
+# https://github.com/databus23/helm-diff
+# =============================================================================
+log_phase "PHASE 33: helm-diff plugin"
+
+helm plugin install https://github.com/databus23/helm-diff
+helm plugin list
+
+# =============================================================================
+# PHASE 34: skaffold — latest stable binary
+# https://skaffold.dev/docs/install/
+# =============================================================================
+log_phase "PHASE 34: skaffold (latest stable)"
+
+curl -fsSL https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 \
+  -o /tmp/skaffold
+install -m 0755 /tmp/skaffold /usr/local/bin/skaffold
+rm /tmp/skaffold
+skaffold version
+
+# =============================================================================
+# PHASE 35: Final cleanup
+# =============================================================================
+log_phase "PHASE 35: Final cleanup"
 
 apt-get autoremove -y
 apt-get clean

--- a/iximiuz/rootfs/dev/machine/welcome
+++ b/iximiuz/rootfs/dev/machine/welcome
@@ -11,6 +11,7 @@
   CONTAINERS      docker    docker-compose    buildx    skopeo    dive    hadolint
   KUBERNETES      kubectl   helm    kustomize    k9s    kubectx    kubens    stern    eksctl
   INFRA & CI/CD   terraform aws cli v2  ansible  ansible-lint  pre-commit  yamllint  gh
+                  act  helmfile  skaffold
   SECURITY        trivy     gitleaks    cosign    syft
   DATA & SEARCH   jq        yq          fzf       rg
   NETWORKING      nmap      openssl     ssh       socat        cloudflared


### PR DESCRIPTION
## Summary

Adds four new tools to the dev machine rootfs toolchain — `act`, `helmfile`, `helm-diff` plugin, and `skaffold` — extending the installer from 29 tools to 33, with a single final cleanup at PHASE 34.

## Changes

### `scripts/install-tools.sh`
- Added `ACT_VERSION="v0.2.89"` and `HELMFILE_VERSION="v1.5.2"` to the pinned versions block
- **PHASE 30** — `act v0.2.89`: GitHub Actions local runner ([nektos/act](https://github.com/nektos/act/releases/tag/v0.2.89))
- **PHASE 31** — `helmfile v1.5.2`: Helm release orchestrator ([helmfile/helmfile](https://github.com/helmfile/helmfile/releases/tag/v1.5.2))
- **PHASE 32** — `helm-diff` plugin: installed via `helm plugin install` ([databus23/helm-diff](https://github.com/databus23/helm-diff)), required by helmfile
- **PHASE 33** — `skaffold` (latest stable): official GCS binary ([skaffold.dev/docs/install](https://skaffold.dev/docs/install/))
- **PHASE 34** — Single final cleanup (removed duplicate that previously existed at PHASE 30)

### `welcome`
- `INFRA & CI/CD` row extended with `act  helmfile  skaffold` on a second line

### `README.md`
- Added `act`, `helmfile`, `helm-diff`, `skaffold` rows to the **What's Inside** table
- Updated directory structure comment: `30 phases` → `34 phases`

## Install Methods

| Tool | Version | Source |
|---|---|---|
| act | v0.2.89 | `act_Linux_x86_64.tar.gz` from GitHub release |
| helmfile | v1.5.2 | `helmfile_1.5.2_linux_amd64.tar.gz` from GitHub release |
| helm-diff | Latest | `helm plugin install https://github.com/databus23/helm-diff` |
| skaffold | Latest stable | `https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64` |
