### PR TITLE
ci/docs: add act local CI workflow support to all build pipelines

### DIFF
--- a/.github/workflows/build-dev-cicd-rootfs.yml
+++ b/.github/workflows/build-dev-cicd-rootfs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,6 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: ${{ !env.ACT }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -71,9 +73,9 @@ jobs:
           context: ./iximiuz/rootfs/dev/ci-cd
           file: ./iximiuz/rootfs/dev/ci-cd/Dockerfile
           platforms: linux/amd64
-          load: false
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: ${{ !!env.ACT }}
+          push: ${{ !env.ACT && github.event_name != 'pull_request' }}
+          tags: ${{ env.ACT && format('{0}:local', env.IMAGE_NAME) || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USER=ibtisam
@@ -81,4 +83,5 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
+        if: ${{ !env.ACT }}
         run: echo "Pushed ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}"

--- a/.github/workflows/build-guacamole-rootfs.yml
+++ b/.github/workflows/build-guacamole-rootfs.yml
@@ -42,6 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -49,6 +50,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: ${{ !env.ACT }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -74,9 +76,9 @@ jobs:
           context: ./iximiuz/rootfs/guacamole
           file: ./iximiuz/rootfs/guacamole/Dockerfile
           platforms: linux/amd64,linux/arm64
-          load: false
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: ${{ !!env.ACT }}
+          push: ${{ !env.ACT && github.event_name != 'pull_request' }}
+          tags: ${{ env.ACT && format('{0}:local', env.IMAGE_NAME) || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USER=ibtisam
@@ -87,4 +89,5 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
+        if: ${{ !env.ACT }}
         run: echo "Pushed ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}"

--- a/.github/workflows/build-jenkins-rootfs.yml
+++ b/.github/workflows/build-jenkins-rootfs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,6 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: ${{ !env.ACT }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -73,9 +75,9 @@ jobs:
           context: ./iximiuz/rootfs/jenkins
           file: ./iximiuz/rootfs/jenkins/Dockerfile
           platforms: linux/amd64
-          load: false
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: ${{ !!env.ACT }}
+          push: ${{ !env.ACT && github.event_name != 'pull_request' }}
+          tags: ${{ env.ACT && format('{0}:local', env.IMAGE_NAME) || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USER=ibtisam
@@ -84,4 +86,5 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
+        if: ${{ !env.ACT }}
         run: echo "Pushed ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}"

--- a/.github/workflows/build-nexus-rootfs.yml
+++ b/.github/workflows/build-nexus-rootfs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,6 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: ${{ !env.ACT }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -73,9 +75,9 @@ jobs:
           context: ./iximiuz/rootfs/nexus
           file: ./iximiuz/rootfs/nexus/Dockerfile
           platforms: linux/amd64
-          load: false
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: ${{ !!env.ACT }}
+          push: ${{ !env.ACT && github.event_name != 'pull_request' }}
+          tags: ${{ env.ACT && format('{0}:local', env.IMAGE_NAME) || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USER=ibtisam
@@ -84,4 +86,5 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
+        if: ${{ !env.ACT }}
         run: echo "Pushed ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}"

--- a/.github/workflows/build-sonarqube-rootfs.yml
+++ b/.github/workflows/build-sonarqube-rootfs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,6 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: ${{ !env.ACT }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -73,9 +75,9 @@ jobs:
           context: ./iximiuz/rootfs/sonarqube
           file: ./iximiuz/rootfs/sonarqube/Dockerfile
           platforms: linux/amd64
-          load: false
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: ${{ !!env.ACT }}
+          push: ${{ !env.ACT && github.event_name != 'pull_request' }}
+          tags: ${{ env.ACT && format('{0}:local', env.IMAGE_NAME) || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USER=ibtisam
@@ -84,4 +86,5 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
+        if: ${{ !env.ACT }}
         run: echo "Pushed ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}"

--- a/.github/workflows/build-ubuntu-rootfs.yml
+++ b/.github/workflows/build-ubuntu-rootfs.yml
@@ -40,6 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
+        if: ${{ !env.ACT }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -47,6 +48,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
+        if: ${{ !env.ACT }}
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -71,9 +73,9 @@ jobs:
           context: ./iximiuz/rootfs/ubuntu
           file: ./iximiuz/rootfs/ubuntu/Dockerfile
           platforms: linux/amd64,linux/arm64
-          load: false
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          load: ${{ !!env.ACT }}
+          push: ${{ !env.ACT && github.event_name != 'pull_request' }}
+          tags: ${{ env.ACT && format('{0}:local', env.IMAGE_NAME) || steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             USER=ibtisam
@@ -85,4 +87,5 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Image digest
+        if: ${{ !env.ACT }}
         run: echo "Pushed ${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}"

--- a/iximiuz/rootfs/guacamole/README.md
+++ b/iximiuz/rootfs/guacamole/README.md
@@ -130,6 +130,32 @@ docker build \
   .
 ```
 
+## Local CI Workflow Testing with `act`
+
+The full CI workflow can be run locally using [`act`](https://github.com/nektos/act) — this builds the image through the same pipeline steps that run on GitHub Actions, without pushing to GHCR and without any secrets. From the root of the `silver-stack` repository:
+
+```bash
+act push \
+  -W .github/workflows/build-guacamole-rootfs.yml \
+  --no-cache-server
+```
+
+The image builds and loads into the local Docker daemon. No GITHUB_TOKEN or GHCR credentials are required.
+
+### Verify the Built Image
+
+```bash
+docker images | grep guacamole-rootfs
+```
+
+## Published Image
+
+The image is built and pushed to GHCR automatically via GitHub Actions on every push to `main`. No manual push is involved.
+
+```bash
+docker pull ghcr.io/ibtisam-iq/guacamole-rootfs:latest
+```
+
 ## Usage in an iximiuz Playground
 
 ```bash

--- a/iximiuz/rootfs/jenkins/README.md
+++ b/iximiuz/rootfs/jenkins/README.md
@@ -124,7 +124,27 @@ docker build \
   .
 ```
 
+## Local CI Workflow Testing with `act`
+
+The full CI workflow can be run locally using [`act`](https://github.com/nektos/act) — this builds the image through the same pipeline steps that run on GitHub Actions, without pushing to GHCR and without any secrets. From the root of the `silver-stack` repository:
+
+```bash
+act push \
+  -W .github/workflows/build-jenkins-rootfs.yml \
+  --no-cache-server
+```
+
+The image builds and loads into the local Docker daemon. No GITHUB_TOKEN or GHCR credentials are required.
+
+### Verify the Built Image
+
+```bash
+docker images | grep jenkins-rootfs
+```
+
 ## Published Image
+
+The image is built and pushed to GHCR automatically via GitHub Actions on every push to `main`. No manual push is involved.
 
 ```bash
 docker pull ghcr.io/ibtisam-iq/jenkins-rootfs:latest
@@ -189,4 +209,3 @@ Post-boot (manual, user-initiated):
 Full setup docs and source references, see my runbook:
 
   https://runbook.ibtisam-iq.com/containers/iximiuz/rootfs/setup-jenkins-rootfs-image
-

--- a/iximiuz/rootfs/nexus/README.md
+++ b/iximiuz/rootfs/nexus/README.md
@@ -76,7 +76,27 @@ docker build \
   .
 ```
 
+## Local CI Workflow Testing with `act`
+
+The full CI workflow can be run locally using [`act`](https://github.com/nektos/act) — this builds the image through the same pipeline steps that run on GitHub Actions, without pushing to GHCR and without any secrets. From the root of the `silver-stack` repository:
+
+```bash
+act push \
+  -W .github/workflows/build-nexus-rootfs.yml \
+  --no-cache-server
+```
+
+The image builds and loads into the local Docker daemon. No GITHUB_TOKEN or GHCR credentials are required.
+
+### Verify the Built Image
+
+```bash
+docker images | grep nexus-rootfs
+```
+
 ## Published Image
+
+The image is built and pushed to GHCR automatically via GitHub Actions on every push to `main`. No manual push is involved.
 
 ```bash
 docker pull ghcr.io/ibtisam-iq/nexus-rootfs:latest

--- a/iximiuz/rootfs/sonarqube/README.md
+++ b/iximiuz/rootfs/sonarqube/README.md
@@ -91,7 +91,27 @@ docker build \
   .
 ```
 
+## Local CI Workflow Testing with `act`
+
+The full CI workflow can be run locally using [`act`](https://github.com/nektos/act) — this builds the image through the same pipeline steps that run on GitHub Actions, without pushing to GHCR and without any secrets. From the root of the `silver-stack` repository:
+
+```bash
+act push \
+  -W .github/workflows/build-sonarqube-rootfs.yml \
+  --no-cache-server
+```
+
+The image builds and loads into the local Docker daemon. No GITHUB_TOKEN or GHCR credentials are required.
+
+### Verify the Built Image
+
+```bash
+docker images | grep sonarqube-rootfs
+```
+
 ## Published Image
+
+The image is built and pushed to GHCR automatically via GitHub Actions on every push to `main`. No manual push is involved.
 
 ```bash
 docker pull ghcr.io/ibtisam-iq/sonarqube-rootfs:latest

--- a/iximiuz/rootfs/ubuntu/README.md
+++ b/iximiuz/rootfs/ubuntu/README.md
@@ -80,7 +80,27 @@ docker build \
   .
 ```
 
+## Local CI Workflow Testing with `act`
+
+The full CI workflow can be run locally using [`act`](https://github.com/nektos/act) — this builds the image through the same pipeline steps that run on GitHub Actions, without pushing to GHCR and without any secrets. From the root of the `silver-stack` repository:
+
+```bash
+act push \
+  -W .github/workflows/build-ubuntu-rootfs.yml \
+  --no-cache-server
+```
+
+The image builds and loads into the local Docker daemon. No GITHUB_TOKEN or GHCR credentials are required.
+
+### Verify the Built Image
+
+```bash
+docker images | grep ubuntu-24-04-rootfs
+```
+
 ## Published Image
+
+The image is built and pushed to GHCR automatically via GitHub Actions on every push to `main`. No manual push is involved.
 
 ```
 docker pull ghcr.io/ibtisam-iq/ubuntu-24-04-rootfs:latest


### PR DESCRIPTION
## Summary

Introduces `act`-aware guards to all `build-*.yml` workflows so the full CI pipeline can be run locally without GHCR credentials, and updates all corresponding READMEs with a **Local CI Workflow Testing with `act`** section.

## Workflow Changes (6 files)

Applied the same 4-change pattern to all remaining `build-*.yml` files (already present in `build-dev-machine-rootfs.yml`):

| Step | Change |
|---|---|
| `Log in to GHCR` | Added `if: ${{ !env.ACT }}` |
| `Extract metadata` | Added `if: ${{ !env.ACT }}` |
| `Build and push` | `load`, `push`, and `tags` made `act`-aware |
| `Image digest` | Added `if: ${{ !env.ACT }}` |

**Files updated:**
- `.github/workflows/build-dev-cicd-rootfs.yml`
- `.github/workflows/build-guacamole-rootfs.yml`
- `.github/workflows/build-jenkins-rootfs.yml`
- `.github/workflows/build-nexus-rootfs.yml`
- `.github/workflows/build-sonarqube-rootfs.yml`
- `.github/workflows/build-ubuntu-rootfs.yml`

## README Changes (5 files)

Added **Local CI Workflow Testing with `act`** section between `Local Build` and `Published Image` in each README. Also added the GitHub Actions publish context line to `Published Image` sections where missing.

**Files updated:**
- `iximiuz/rootfs/jenkins/README.md`
- `iximiuz/rootfs/nexus/README.md`
- `iximiuz/rootfs/sonarqube/README.md`
- `iximiuz/rootfs/ubuntu/README.md`
- `iximiuz/rootfs/guacamole/README.md` (also added missing `Published Image` section)

## Testing

Verified locally on `build-dev-machine-rootfs.yml`:

```bash
act push \
  -W .github/workflows/build-dev-machine-rootfs.yml \
  --no-cache-server
```

Image builds and loads into local Docker daemon. No secrets required.