### PR TITLE
feat(dev-machine): add lychee v0.24.2 link checker

### DIFF
--- a/iximiuz/rootfs/dev/machine/README.md
+++ b/iximiuz/rootfs/dev/machine/README.md
@@ -38,6 +38,7 @@ A child image built on top of [`ubuntu-24-04-rootfs`](../../ubuntu/README.md). U
 | helmfile | v1.5.2 | GitHub release |
 | helm-diff | Latest (via `helm plugin install`) | Helm plugin |
 | skaffold | Latest stable | Official GCS binary |
+| lychee | v0.24.2 | GitHub release |
 | Skopeo | Latest | `apt` |
 | dive | v0.13.1 | GitHub release |
 | hadolint | v2.12.0 | GitHub release |
@@ -66,7 +67,7 @@ dev/machine/
 ├── welcome                            # Welcome banner (copied to $HOME/.welcome)
 └── scripts/
     ├── install-docker.sh              # Docker CE - official Docker apt repo
-    ├── install-tools.sh               # Full DevOps toolchain - 34 phases
+    ├── install-tools.sh               # Full DevOps toolchain - 35 phases
     ├── install-cloudflared.sh         # Cloudflare Tunnel CLI
     ├── setup-completions.sh           # System-wide bash + zsh completions
     └── customize-bashrc.sh            # Aliases and helpers → ~/.bashrc

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -514,7 +514,7 @@ skaffold version
 # =============================================================================
 log_phase "PHASE 34: lychee ${LYCHEE_VERSION}"
 
-curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
   -o /tmp/lychee.tar.gz
 tar -xzf /tmp/lychee.tar.gz -C /usr/local/bin lychee
 chmod +x /usr/local/bin/lychee

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -39,6 +39,7 @@ SYFT_VERSION="v1.26.1"
 EKSCTL_VERSION="v0.226.0"
 ACT_VERSION="v0.2.89"
 HELMFILE_VERSION="v1.5.2"
+LYCHEE_VERSION="v0.24.2"
 
 # =============================================================================
 # PHASE 1: Base system packages
@@ -508,9 +509,22 @@ rm /tmp/skaffold
 skaffold version
 
 # =============================================================================
-# PHASE 34: Final cleanup
+# PHASE 34: lychee — fast link checker
+# https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.24.2
 # =============================================================================
-log_phase "PHASE 34: Final cleanup"
+log_phase "PHASE 34: lychee ${LYCHEE_VERSION}"
+
+curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+  -o /tmp/lychee.tar.gz
+tar -xzf /tmp/lychee.tar.gz -C /usr/local/bin lychee
+chmod +x /usr/local/bin/lychee
+rm /tmp/lychee.tar.gz
+lychee --version
+
+# =============================================================================
+# PHASE 35: Final cleanup
+# =============================================================================
+log_phase "PHASE 35: Final cleanup"
 
 apt-get autoremove -y
 apt-get clean

--- a/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
+++ b/iximiuz/rootfs/dev/machine/scripts/install-tools.sh
@@ -516,9 +516,10 @@ log_phase "PHASE 34: lychee ${LYCHEE_VERSION}"
 
 curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" \
   -o /tmp/lychee.tar.gz
-tar -xzf /tmp/lychee.tar.gz -C /usr/local/bin lychee
-chmod +x /usr/local/bin/lychee
-rm /tmp/lychee.tar.gz
+mkdir -p /tmp/lychee-extract
+tar -xzf /tmp/lychee.tar.gz -C /tmp/lychee-extract
+find /tmp/lychee-extract -maxdepth 2 -type f -name 'lychee*' | head -1 | xargs -I{} install -m 0755 {} /usr/local/bin/lychee
+rm -rf /tmp/lychee.tar.gz /tmp/lychee-extract
 lychee --version
 
 # =============================================================================

--- a/iximiuz/rootfs/dev/machine/welcome
+++ b/iximiuz/rootfs/dev/machine/welcome
@@ -14,7 +14,7 @@
                   act  helmfile  skaffold
   SECURITY        trivy     gitleaks    cosign    syft
   DATA & SEARCH   jq        yq          fzf       rg
-  NETWORKING      nmap      openssl     ssh       socat        cloudflared
+  NETWORKING      nmap      openssl     ssh       socat        cloudflared    lychee
   DB CLIENTS      mysql     psql        sqlite3   redis-cli    mongosh
 
   Pre-defined shortcuts:


### PR DESCRIPTION
## Summary

Adds [lychee](https://github.com/lycheeverse/lychee) — a fast, async link checker written in Rust — to the dev-machine toolchain.

**Release:** [`lychee-v0.24.2`](https://github.com/lycheeverse/lychee/releases/tag/lychee-v0.24.2)

## Changes

### `scripts/install-tools.sh`
- Added `LYCHEE_VERSION="v0.24.2"` to the pinned versions block
- Added **PHASE 34** installer: downloads the `lychee-v0.24.2-x86_64-unknown-linux-gnu.tar.gz` tarball from the GitHub release, extracts the binary to `/usr/local/bin/lychee`, and verifies with `lychee --version`
- Renumbered former PHASE 34 (Final cleanup) → **PHASE 35**
- Updated phase count comment in directory structure: `34 phases` → `35 phases`

### `welcome`
- Added `lychee` to the `NETWORKING` row in the pre-installed tools banner

### `README.md`
- Added `lychee` row to the **What's Inside** table (`v0.24.2` / GitHub release)
- Updated `install-tools.sh` comment from `34 phases` → `35 phases` in the Directory Structure section

## Install pattern

Follows the existing binary-from-tarball pattern used by `stern`, `gitleaks`, `dive`, etc.:

```bash
curl -fsSL "https://github.com/lycheeverse/lychee/releases/download/lychee-${LYCHEE_VERSION}/lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
  -o /tmp/lychee.tar.gz
tar -xzf /tmp/lychee.tar.gz -C /usr/local/bin lychee
chmod +x /usr/local/bin/lychee
rm /tmp/lychee.tar.gz
lychee --version
```

> lychee is placed in the `NETWORKING` group in the welcome banner because its primary use is checking URLs/links — outbound network verification.